### PR TITLE
Fixed backupDisk in StoreNodeRequest.php

### DIFF
--- a/app/Http/Requests/Api/Application/Nodes/StoreNodeRequest.php
+++ b/app/Http/Requests/Api/Application/Nodes/StoreNodeRequest.php
@@ -35,7 +35,7 @@ class StoreNodeRequest extends ApplicationApiRequest
             'daemonSFTP',
             'daemonBase',
             'daemonType',
-            'daemonDisk'
+            'backupDisk'
         ])->mapWithKeys(function ($value, $key) {
             $key = ($key === 'daemonSFTP') ? 'daemonSftp' : $key;
 
@@ -66,8 +66,9 @@ class StoreNodeRequest extends ApplicationApiRequest
         $response['daemonListen'] = $response['daemon_listen'];
         $response['daemonSFTP'] = $response['daemon_sftp'];
         $response['daemonBase'] = $response['daemon_base'] ?? (new Node())->getAttribute('daemonBase');
+        $response['backupDisk'] = $response['backup_disk'] ?? (new Node())->getAttribute('backupDisk');
 
-        unset($response['daemon_base'], $response['daemon_listen'], $response['daemon_sftp']);
+        unset($response['daemon_base'], $response['daemon_listen'], $response['daemon_sftp'], $response['backup_disk']);
 
         return $response;
     }

--- a/app/Http/Requests/Api/Application/Nodes/StoreNodeRequest.php
+++ b/app/Http/Requests/Api/Application/Nodes/StoreNodeRequest.php
@@ -66,9 +66,10 @@ class StoreNodeRequest extends ApplicationApiRequest
         $response['daemonListen'] = $response['daemon_listen'];
         $response['daemonSFTP'] = $response['daemon_sftp'];
         $response['daemonBase'] = $response['daemon_base'] ?? (new Node())->getAttribute('daemonBase');
+        $response['daemonType'] = $response['daemon_type'] ?? (new Node())->getAttribute('daemonType');
         $response['backupDisk'] = $response['backup_disk'] ?? (new Node())->getAttribute('backupDisk');
 
-        unset($response['daemon_base'], $response['daemon_listen'], $response['daemon_sftp'], $response['backup_disk']);
+        unset($response['daemon_base'], $response['daemon_listen'], $response['daemon_sftp'], $response['daemon_type'], $response['backup_disk']);
 
         return $response;
     }

--- a/app/Models/Node.php
+++ b/app/Models/Node.php
@@ -140,8 +140,8 @@ class Node extends Model
         'daemonListen' => 'required|numeric|between:1,65535',
         'maintenance_mode' => 'boolean',
         'upload_size' => 'int|between:1,1024',
-        'daemonType' => 'required|string',
-        'backupDisk' => 'required|string'
+        'daemonType' => 'nullable|string',
+        'backupDisk' => 'nullable|string'
     ];
 
     /**

--- a/app/Models/Node.php
+++ b/app/Models/Node.php
@@ -158,6 +158,8 @@ class Node extends Model
         'daemonListen' => 8080,
         'maintenance_mode' => false,
         'use_separate_fqdns' => false,
+        'daemonType' => 'elytra',
+        'backupDisk' => 'rustic_local',
     ];
 
 


### PR DESCRIPTION
For some ungodly reason, the node api was requiring daemonDisk while the rest of the codebase requires backupDisk.
This fixes the issue properly so I don't need to have a patch file in the installer script.