### PR TITLE
fix(schedule): change return to break to allow subsequent tasks to run

### DIFF
--- a/app/Jobs/Schedule/RunTaskJob.php
+++ b/app/Jobs/Schedule/RunTaskJob.php
@@ -93,7 +93,7 @@ class RunTaskJob extends Job implements ShouldQueue
                             'schedule_id' => $this->task->schedule_id,
                             'server_id' => $server->id,
                         ]);
-                        return;
+                        break;
                     }
 
                     try {


### PR DESCRIPTION
I found a bug in `RunTaskJob.php` where using `return;` inside the backup action catch block (line 96) causes the entire job to exit. This prevents any subsequent tasks in the schedule from running if a backup task is processed.

Fix: Changed `return;` to `break;` so the loop can continue to the next task in the sequence.

This explains why schedules with multiple task were getting stuck on "Processing" and skipping the final tasks.