### PR TITLE
feat(settings): consolidate Startup + Software into a single Settings page

### DIFF
--- a/resources/scripts/components/elements/Modal.tsx
+++ b/resources/scripts/components/elements/Modal.tsx
@@ -1,7 +1,7 @@
 import { Xmark } from '@gravity-ui/icons';
 import { Dialog as HDialog } from '@headlessui/react';
 import { AnimatePresence, motion } from 'motion/react';
-import { useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import styled from 'styled-components';
 
 import ActionButton from '@/components/elements/ActionButton';
@@ -49,6 +49,13 @@ export interface ModalProps extends RequiredModalProps {
     closeOnEscape?: boolean;
     closeOnBackground?: boolean;
     showSpinnerOverlay?: boolean;
+    /**
+     * Extra Tailwind utility classes appended to the panel. Mainly used to
+     * override the default `max-w-xl` width cap for modals whose content
+     * needs more room (e.g. the Change Software wizard, which has 3-col
+     * grids of nest/egg cards that look cramped at 576px).
+     */
+    panelClassName?: string;
 }
 
 export const ModalMask = styled.div`
@@ -66,9 +73,12 @@ const Modal: React.FC<ModalProps> = ({
     visible,
     closeButton,
     dismissable = true,
+    closeOnEscape = true,
+    closeOnBackground = true,
     showSpinnerOverlay,
     onDismissed,
     children,
+    panelClassName,
 }) => {
     const isDismissable = useMemo(() => {
         return dismissable && !showSpinnerOverlay;
@@ -86,11 +96,52 @@ const Modal: React.FC<ModalProps> = ({
         }
     };
 
+    /**
+     * HeadlessUI Dialog's `onClose` fires for both Escape and clicks
+     * outside the Panel without telling us which one. The default
+     * behaviour (treat both as a dismiss) is fine for simple confirm
+     * dialogs but actively breaks multi-step flows like the change-
+     * software wizard: when a click handler inside the modal runs
+     * setState (advancing to the next step), React reconciles and
+     * the click's original DOM target can be detached by the time
+     * HeadlessUI's outside-click detector walks the ancestor chain.
+     * The detector then concludes the target wasn't inside the Panel
+     * and fires onClose — closing the modal even though the user
+     * clicked a button INSIDE it. The visible symptom is a flicker-
+     * close on every action button.
+     *
+     * Fix: when `closeOnBackground={false}`, we no-op the entire
+     * HDialog.onClose channel (since we can't distinguish Escape from
+     * outside-click) and run our own Escape listener in the effect
+     * below, gated by `closeOnEscape`.
+     */
     const onDialogClose = (): void => {
-        if (isDismissable) {
-            return onDismissed();
-        }
+        if (!isDismissable) return;
+        // Background close is the only path that funnels through here
+        // when we trust HDialog. When the caller has opted out via
+        // closeOnBackground={false}, suppress it entirely. Escape is
+        // handled separately in the effect below.
+        if (!closeOnBackground) return;
+        return onDismissed();
     };
+
+    // Manual Escape handler — runs whenever the modal is visible AND
+    // the caller wants Escape to dismiss. Used in tandem with
+    // closeOnBackground={false} to keep "Escape closes / clicks-inside
+    // don't" semantics that HeadlessUI's single onClose channel can't
+    // express on its own.
+    useEffect(() => {
+        if (!visible || !closeOnEscape || !isDismissable) return;
+        // Skip when we're already delegating Escape to HDialog (i.e.
+        // outside-click is also allowed) — otherwise Escape would fire
+        // both handlers and we'd risk a double-dismiss flicker.
+        if (closeOnBackground) return;
+        const onKey = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') onDismissed();
+        };
+        document.addEventListener('keydown', onKey);
+        return () => document.removeEventListener('keydown', onKey);
+    }, [visible, closeOnEscape, closeOnBackground, isDismissable, onDismissed]);
 
     return (
         <>
@@ -135,7 +186,12 @@ const Modal: React.FC<ModalProps> = ({
                                         animate={down ? 'bounce' : 'open'}
                                         exit={'closed'}
                                         variants={variants}
-                                        className={styles.panel}
+                                        // panelClassName is appended after
+                                        // styles.panel so Tailwind utilities
+                                        // (e.g. max-w-5xl) take precedence
+                                        // over the default max-w-xl baked
+                                        // into the CSS module.
+                                        className={`${styles.panel} ${panelClassName ?? ''}`}
                                     >
                                         <div className='place-content-between flex items-center m-6'>
                                             {title && <h2 className={`text-2xl text-zinc-100`}>{title}</h2>}

--- a/resources/scripts/components/server/settings/ReinstallServerBox.tsx
+++ b/resources/scripts/components/server/settings/ReinstallServerBox.tsx
@@ -1,8 +1,8 @@
+import { TriangleExclamation } from '@gravity-ui/icons';
 import { Actions, useStoreActions } from 'easy-peasy';
 import { useEffect, useState } from 'react';
 
 import ActionButton from '@/components/elements/ActionButton';
-import TitledGreyBox from '@/components/elements/TitledGreyBox';
 import { Dialog } from '@/components/elements/dialog';
 
 import { httpErrorToHuman } from '@/api/http';
@@ -11,6 +11,12 @@ import reinstallServer from '@/api/server/reinstallServer';
 import { ApplicationStore } from '@/state';
 import { ServerContext } from '@/state/server';
 
+/**
+ * Reinstall card — danger-zone styled with a clear red border to mark it
+ * out from the other settings cards. Reinstall is the only setting on
+ * this page that can destroy player data, so it gets its own visual
+ * weight and a confirm dialog.
+ */
 const ReinstallServerBox = () => {
     const uuid = ServerContext.useStoreState((state) => state.server.data!.uuid);
     const [modalVisible, setModalVisible] = useState(false);
@@ -30,7 +36,6 @@ const ReinstallServerBox = () => {
             })
             .catch((error) => {
                 console.error(error);
-
                 addFlash({ key: 'settings', type: 'error', message: httpErrorToHuman(error) });
             })
             .then(() => {
@@ -44,32 +49,32 @@ const ReinstallServerBox = () => {
     }, []);
 
     return (
-        <TitledGreyBox title={'Reinstall Server'}>
+        <section className='rounded-2xl border border-red-500/30 bg-red-500/[0.04] transition hover:duration-0 hover:border-red-500/50 hover:bg-red-500/[0.07]'>
+            <header className='flex items-center gap-2 border-b border-red-500/20 px-5 py-3.5'>
+                <TriangleExclamation width={16} height={16} className='text-red-400' />
+                <h2 className='text-sm font-semibold text-red-200'>Reinstall Server</h2>
+            </header>
             <Dialog.Confirm
                 open={modalVisible}
-                title={'Confirm server reinstallation'}
-                confirm={'Yes, reinstall server'}
+                title='Confirm server reinstallation'
+                confirm='Yes, reinstall server'
                 onClose={() => setModalVisible(false)}
                 onConfirmed={reinstall}
                 loading={loading}
             >
-                Your server will be stopped and some files may be deleted or modified during this process, are you sure
-                you wish to continue?
+                Your server will be stopped and some files may be deleted or modified during this
+                process, are you sure you wish to continue?
             </Dialog.Confirm>
-            <p className={`text-sm`}>
-                Reinstalling your server will stop it, and then re-run the installation script that initially set it
-                up.&nbsp;
-                <strong className={`font-medium`}>
-                    Some files may be deleted or modified during this process, please back up your data before
-                    continuing.
-                </strong>
-            </p>
-            <div className={`mt-6 text-right`}>
-                <ActionButton variant='danger' onClick={() => setModalVisible(true)}>
+            <div className='flex flex-col gap-3 p-5 sm:flex-row sm:items-center sm:justify-between'>
+                <p className='text-xs text-zinc-300'>
+                    Re-runs the installation script that initially set this server up. Existing files may be
+                    deleted or modified — back up your data first.
+                </p>
+                <ActionButton variant='danger' size='sm' onClick={() => setModalVisible(true)}>
                     Reinstall Server
                 </ActionButton>
             </div>
-        </TitledGreyBox>
+        </section>
     );
 };
 

--- a/resources/scripts/components/server/settings/RenameServerBox.tsx
+++ b/resources/scripts/components/server/settings/RenameServerBox.tsx
@@ -1,11 +1,12 @@
+import { Copy, Tag } from '@gravity-ui/icons';
 import { Actions, useStoreActions } from 'easy-peasy';
-import { Form, Formik } from 'formik';
+import { Form, Formik, useFormikContext } from 'formik';
 import { toast } from 'sonner';
 import { object, string } from 'yup';
 
 import ActionButton from '@/components/elements/ActionButton';
+import CopyOnClick from '@/components/elements/CopyOnClick';
 import Field from '@/components/elements/Field';
-import TitledGreyBox from '@/components/elements/TitledGreyBox';
 
 import { httpErrorToHuman } from '@/api/http';
 import renameServer from '@/api/server/renameServer';
@@ -18,53 +19,117 @@ interface Values {
     description: string;
 }
 
-const RenameServerForm = () => {
+/**
+ * Inner form. Reading dirty/submitting from Formik lets us disable Save
+ * when there are no pending changes. Layout is a 3-column grid on wide
+ * viewports — Name | Description | Save — so the Save button reads as
+ * the third edit affordance rather than a footer action floating
+ * underneath two text inputs.
+ */
+const RenameInnerForm = ({ initial }: { initial: Values }) => {
+    const { values, isSubmitting } = useFormikContext<Values>();
+    const dirty = values.name.trim() !== initial.name || (values.description ?? '') !== (initial.description ?? '');
+
     return (
-        <TitledGreyBox title={'Server Details'}>
-            <Form className='flex flex-col gap-4'>
-                <Field id={'name'} name={'name'} label={'Server Name'} type={'text'} />
-                <Field id={'description'} name={'description'} label={'Server Description'} type={'text'} />
-                <div className={`mt-6 text-right`}>
-                    <ActionButton variant='primary' type={'submit'}>
-                        Save
-                    </ActionButton>
-                </div>
-            </Form>
-        </TitledGreyBox>
+        <Form className='grid grid-cols-1 items-end gap-4 md:grid-cols-[1fr_1fr_auto]'>
+            <Field id='name' name='name' label='Server Name' type='text' />
+            <Field id='description' name='description' label='Server Description' type='text' />
+            {/* Save lives in the third grid column on md+ viewports so
+                the row reads as "Name | Description | Save". `mb-1`
+                aligns the button vertically with the input bottoms
+                (Field renders its own label above the input, so without
+                this nudge Save sits a few pixels too low). */}
+            <ActionButton
+                variant='primary'
+                size='md'
+                type='submit'
+                disabled={!dirty || isSubmitting}
+                className='mb-1 w-full md:w-auto'
+            >
+                Save
+            </ActionButton>
+        </Form>
     );
 };
 
+/**
+ * Server identity card — name + description editor.
+ *
+ * Replaces the old TitledGreyBox-wrapped form whose Save button dangled
+ * underneath two wide inputs in an awkward "what are we even saving?"
+ * way. Now the inputs + Save live side-by-side on a single row (stacking
+ * on narrow viewports) and the Server UUID rides up in the card header,
+ * right-aligned beside the title — same place the Resources card shows
+ * its Node id, so identity-style diagnostics consistently live in card
+ * headers.
+ */
 const RenameServerBox = () => {
     const server = ServerContext.useStoreState((state) => state.server.data!);
     const setServer = ServerContext.useStoreActions((actions) => actions.server.setServer);
     const { addError, clearFlashes } = useStoreActions((actions: Actions<ApplicationStore>) => actions.flashes);
 
+    const initial: Values = {
+        name: server.name,
+        description: server.description ?? '',
+    };
+
     const submit = ({ name, description }: Values) => {
         clearFlashes('settings');
-        toast('Updating server details...');
-        renameServer(server.uuid, name, description)
-            .then(() => setServer({ ...server, name, description }))
-            .catch((error) => {
-                console.error(error);
-                addError({ key: 'settings', message: httpErrorToHuman(error) });
-            })
-            .then(() => toast.success('Server details updated!'));
+        const trimmedName = name.trim();
+        toast.promise(
+            renameServer(server.uuid, trimmedName, description).then(() =>
+                setServer({ ...server, name: trimmedName, description }),
+            ),
+            {
+                loading: 'Saving server details…',
+                success: 'Server details updated.',
+                error: (error) => {
+                    addError({ key: 'settings', message: httpErrorToHuman(error) });
+                    return httpErrorToHuman(error);
+                },
+            },
+        );
     };
 
     return (
-        <Formik
-            onSubmit={submit}
-            initialValues={{
-                name: server.name,
-                description: server.description,
-            }}
-            validationSchema={object().shape({
-                name: string().required().min(1),
-                description: string().nullable(),
-            })}
-        >
-            <RenameServerForm />
-        </Formik>
+        <section className='rounded-2xl border border-[#ffffff10] bg-[#ffffff05] transition hover:duration-0 hover:border-[#ffffff20] hover:bg-[#ffffff08]'>
+            <header className='flex flex-wrap items-center gap-2 border-b border-[#ffffff10] px-5 py-3.5'>
+                <Tag width={16} height={16} className='text-zinc-400' />
+                <h2 className='text-sm font-semibold text-zinc-100'>Server Identity</h2>
+                {/* Server UUID in the header, right-aligned. Same shape
+                    as the Node chip on the Resources card so the two
+                    cards' diagnostic chips visually rhyme. */}
+                <CopyOnClick text={server.uuid}>
+                    <span
+                        title={server.uuid}
+                        className='group ml-auto inline-flex max-w-full cursor-pointer items-center gap-1.5 rounded-md bg-[#ffffff08] px-2 py-1 font-mono text-[11px] text-zinc-200 transition hover:bg-[#ffffff14]'
+                    >
+                        <span className='text-[10px] font-bold uppercase tracking-wide text-zinc-500'>
+                            Server UUID
+                        </span>
+                        <span className='break-all'>{server.uuid}</span>
+                        <Copy
+                            width={11}
+                            height={11}
+                            className='shrink-0 text-zinc-500 group-hover:text-zinc-200'
+                        />
+                    </span>
+                </CopyOnClick>
+            </header>
+            <div className='p-5'>
+                <Formik
+                    onSubmit={submit}
+                    initialValues={initial}
+                    enableReinitialize
+                    validationSchema={object().shape({
+                        name: string().required().min(1),
+                        description: string().nullable(),
+                    })}
+                >
+                    <RenameInnerForm initial={initial} />
+                </Formik>
+            </div>
+        </section>
     );
 };
 

--- a/resources/scripts/components/server/settings/ServerConnectionCard.tsx
+++ b/resources/scripts/components/server/settings/ServerConnectionCard.tsx
@@ -1,0 +1,122 @@
+import { Copy, PlugConnection } from '@gravity-ui/icons';
+import { useStoreState } from 'easy-peasy';
+import isEqual from 'react-fast-compare';
+
+import ActionButton from '@/components/elements/ActionButton';
+import CopyOnClick from '@/components/elements/CopyOnClick';
+
+import { ip } from '@/lib/formatters';
+
+import { ServerContext } from '@/state/server';
+
+/**
+ * Connection card — a single panel that surfaces every "how do I connect"
+ * detail that used to be sprinkled across the old Debug Info, SFTP
+ * Details, and Startup environment-variable tiles.
+ *
+ * The old layout split server IP/port (advertised under the SERVER_IP /
+ * SERVER_PORT env-var tiles) away from SFTP (its own card on the General
+ * section). Players don't think of those as separate concepts — they're
+ * both "addresses you connect to" — so we merge them into one card with
+ * clearly labelled rows.
+ *
+ * The "Launch SFTP" affordance gets bumped to a real primary-coloured
+ * button because the previous secondary-styled grey button looked
+ * disabled. Players regularly missed it on the old screen.
+ */
+const ServerConnectionCard = () => {
+    const username = useStoreState((state) => state.user.data!.username);
+    const serverId = ServerContext.useStoreState((state) => state.server.data!.id);
+    const sftp = ServerContext.useStoreState((state) => state.server.data!.sftpDetails, isEqual);
+    const allocations = ServerContext.useStoreState((state) => state.server.data!.allocations, isEqual);
+    const primary = allocations.find((a) => a.isDefault) ?? allocations[0];
+
+    const gameAddress = primary ? `${ip(primary.ip)}:${primary.port}` : null;
+    const sftpUrl = `sftp://${username}.${serverId}@${ip(sftp.ip)}:${sftp.port}`;
+    const sftpAddress = `${ip(sftp.ip)}:${sftp.port}`;
+    const sftpUsername = `${username}.${serverId}`;
+
+    return (
+        <section className='rounded-2xl border border-[#ffffff10] bg-[#ffffff05] transition hover:duration-0 hover:border-[#ffffff20] hover:bg-[#ffffff08]'>
+            <header className='flex items-center gap-2 border-b border-[#ffffff10] px-5 py-3.5'>
+                <PlugConnection width={16} height={16} className='text-zinc-400' />
+                <h2 className='text-sm font-semibold text-zinc-100'>Connection</h2>
+            </header>
+            <div className='grid grid-cols-1 gap-x-6 gap-y-5 p-5 md:grid-cols-2'>
+                {/* Game-server address — what players paste into their
+                    Minecraft client. Pulled from the default allocation. */}
+                <ConnectionRow
+                    label='Game Address'
+                    value={gameAddress ?? '—'}
+                    copyText={gameAddress ?? undefined}
+                    hint='Players connect to this address from their game client.'
+                />
+                {/* Empty grid cell on md+ so the SFTP block lines up
+                    cleanly below the game-address row on wider viewports. */}
+                <ConnectionRow
+                    label='SFTP Address'
+                    value={sftpAddress}
+                    copyText={sftpAddress}
+                    hint='For SFTP clients like FileZilla or WinSCP.'
+                />
+                <ConnectionRow
+                    label='SFTP Username'
+                    value={sftpUsername}
+                    copyText={sftpUsername}
+                    hint='Use the same password you log in to this panel with.'
+                />
+                {/* SFTP launcher cell — helper text on the left wraps
+                    onto two lines to balance the visual weight of the
+                    button on the right. The button hugs its label
+                    rather than stretching, and text + button stay on
+                    one row on md+ (stacks on phones). */}
+                <div className='flex flex-col items-start gap-3 sm:flex-row sm:items-center sm:justify-between'>
+                    <p className='max-w-[20ch] text-xs leading-snug text-zinc-400'>
+                        Open SFTP in your default client without copying credentials manually.
+                    </p>
+                    <a href={sftpUrl} className='shrink-0'>
+                        <ActionButton variant='primary' size='md'>
+                            Launch SFTP
+                        </ActionButton>
+                    </a>
+                </div>
+            </div>
+        </section>
+    );
+};
+
+/** One labelled value row inside the Connection card. */
+const ConnectionRow = ({
+    label,
+    value,
+    copyText,
+    hint,
+}: {
+    label: string;
+    value: string;
+    copyText?: string;
+    hint?: string;
+}) => (
+    <div className='flex flex-col gap-1.5'>
+        <span className='text-[10px] font-bold uppercase tracking-wide text-zinc-500'>{label}</span>
+        {copyText ? (
+            <CopyOnClick text={copyText}>
+                <div className='group inline-flex w-full cursor-pointer items-center justify-between gap-2 rounded-lg border border-[#ffffff10] bg-[#ffffff08] px-3 py-2 transition hover:border-brand/40 hover:bg-[#ffffff12]'>
+                    <span className='truncate font-mono text-sm text-zinc-100'>{value}</span>
+                    <Copy
+                        width={14}
+                        height={14}
+                        className='shrink-0 text-zinc-500 transition group-hover:text-zinc-200'
+                    />
+                </div>
+            </CopyOnClick>
+        ) : (
+            <div className='inline-flex w-full items-center rounded-lg border border-[#ffffff10] bg-[#ffffff08] px-3 py-2'>
+                <span className='truncate font-mono text-sm text-zinc-100'>{value}</span>
+            </div>
+        )}
+        {hint && <span className='text-[11px] text-zinc-500'>{hint}</span>}
+    </div>
+);
+
+export default ServerConnectionCard;

--- a/resources/scripts/components/server/settings/ServerResourcesCard.tsx
+++ b/resources/scripts/components/server/settings/ServerResourcesCard.tsx
@@ -1,0 +1,112 @@
+import { Copy, Cpu, Cube, HardDrive } from '@gravity-ui/icons';
+import { useMemo } from 'react';
+import isEqual from 'react-fast-compare';
+
+import CopyOnClick from '@/components/elements/CopyOnClick';
+
+import { ServerContext } from '@/state/server';
+
+/**
+ * Format a megabyte limit value. 0 means "unlimited" in the Pterodactyl
+ * model so we surface that explicitly instead of "0 MB".
+ */
+const formatMemory = (mb: number): string => {
+    if (mb === 0) return 'Unlimited';
+    if (mb >= 1024) return `${(mb / 1024).toFixed(mb % 1024 === 0 ? 0 : 1)} GiB`;
+    return `${mb} MiB`;
+};
+
+/**
+ * CPU is exposed as a percentage in the Pterodactyl model, where 100 ==
+ * one full core. 0 means "unlimited". We round to the nearest integer for
+ * display because fractional CPU percentages aren't a thing the user
+ * cares about at a glance.
+ */
+const formatCpu = (pct: number): string => {
+    if (pct === 0) return 'Unlimited';
+    return `${Math.round(pct)}%`;
+};
+
+/**
+ * Resources card — replaces the cramped SERVER_MEMORY / SERVER_CPU env-
+ * variable tiles that used to live in the Startup section. Same data,
+ * displayed as visual tiles with units and human-friendly labels instead
+ * of `null`-friendly raw strings. Three tiles: Memory, CPU, Disk.
+ *
+ * Hosts the **Node** line in its footer because "which physical node am
+ * I on" is conceptually a resource provisioning attribute, lives at the
+ * same data-source (server.node alongside server.limits), and the user
+ * explicitly asked to collapse the old standalone Diagnostics footer
+ * into the cards that own the related data.
+ *
+ * We deliberately stop short of plumbing in live usage (that's the Home
+ * page's job). This card is about provisioned limits — what the server
+ * is allowed to use — not what it's currently using.
+ */
+const ServerResourcesCard = () => {
+    const limits = ServerContext.useStoreState((state) => state.server.data!.limits, isEqual);
+    const node = ServerContext.useStoreState((state) => state.server.data!.node);
+    const tiles = useMemo(
+        () => [
+            {
+                icon: <Cube width={18} height={18} />,
+                label: 'Memory',
+                value: formatMemory(limits.memory),
+                accent: 'text-emerald-300',
+            },
+            {
+                icon: <Cpu width={18} height={18} />,
+                label: 'CPU',
+                value: formatCpu(limits.cpu),
+                accent: 'text-sky-300',
+            },
+            {
+                icon: <HardDrive width={18} height={18} />,
+                label: 'Disk',
+                value: formatMemory(limits.disk),
+                accent: 'text-amber-300',
+            },
+        ],
+        [limits],
+    );
+
+    return (
+        <section className='rounded-2xl border border-[#ffffff10] bg-[#ffffff05] transition hover:duration-0 hover:border-[#ffffff20] hover:bg-[#ffffff08]'>
+            <header className='flex items-center gap-2 border-b border-[#ffffff10] px-5 py-3.5'>
+                <Cpu width={16} height={16} className='text-zinc-400' />
+                <h2 className='text-sm font-semibold text-zinc-100'>Resources</h2>
+                <span className='ml-2 text-[11px] text-zinc-500'>provisioned limits</span>
+                {/* Node id lives in the header strip rather than a
+                    separate footer row — same surface, less vertical
+                    space. ml-auto pushes it to the far right so the
+                    visual hierarchy is "title + subtitle on the left,
+                    diagnostics chip on the right". */}
+                <CopyOnClick text={node}>
+                    <span className='group ml-auto inline-flex cursor-pointer items-center gap-1.5 rounded-md bg-[#ffffff08] px-2 py-1 font-mono text-[11px] text-zinc-200 transition hover:bg-[#ffffff14]'>
+                        <span className='text-[10px] font-bold uppercase tracking-wide text-zinc-500'>Node</span>
+                        <span>{node}</span>
+                        <Copy width={11} height={11} className='text-zinc-500 group-hover:text-zinc-200' />
+                    </span>
+                </CopyOnClick>
+            </header>
+            <div className='grid grid-cols-1 gap-3 p-5 sm:grid-cols-3'>
+                {tiles.map((tile) => (
+                    <div
+                        key={tile.label}
+                        className='flex items-center gap-3 rounded-xl border border-[#ffffff10] bg-[#ffffff06] p-4'
+                    >
+                        <span className={tile.accent}>{tile.icon}</span>
+                        <div className='flex min-w-0 flex-col'>
+                            <span className='text-[10px] font-bold uppercase tracking-wide text-zinc-500'>
+                                {tile.label}
+                            </span>
+                            <span className='truncate text-sm font-semibold text-zinc-100'>{tile.value}</span>
+                        </div>
+                    </div>
+                ))}
+            </div>
+        </section>
+    );
+};
+
+export default ServerResourcesCard;

--- a/resources/scripts/components/server/settings/SettingsContainer.tsx
+++ b/resources/scripts/components/server/settings/SettingsContainer.tsx
@@ -1,93 +1,99 @@
-import { useStoreState } from 'easy-peasy';
-import isEqual from 'react-fast-compare';
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
 
 import FlashMessageRender from '@/components/FlashMessageRender';
-import ActionButton from '@/components/elements/ActionButton';
 import Can from '@/components/elements/Can';
-import CopyOnClick from '@/components/elements/CopyOnClick';
-import Label from '@/components/elements/Label';
 import { MainPageHeader } from '@/components/elements/MainPageHeader';
 import ServerContentBlock from '@/components/elements/ServerContentBlock';
-import TitledGreyBox from '@/components/elements/TitledGreyBox';
-import ReinstallServerBox from '@/components/server/settings/ReinstallServerBox';
+import StartupContainer from '@/components/server/startup/StartupContainer';
 
-import { ip } from '@/lib/formatters';
-
-import { ServerContext } from '@/state/server';
-
+import ShellContainer from '../shell/ShellContainer';
+import ReinstallServerBox from './ReinstallServerBox';
 import RenameServerBox from './RenameServerBox';
+import ServerConnectionCard from './ServerConnectionCard';
+import ServerResourcesCard from './ServerResourcesCard';
 
+/**
+ * Consolidated Settings page.
+ *
+ * Single unified page that replaces the previous three sidebar entries —
+ * Startup, Settings, Software. Drops section labels and rebuilds around
+ * the questions a user actually asks when they open Settings:
+ *
+ *   1. "What software am I running, and how do I change it?"        → Software card (top)
+ *   2. "What's this server called?" + "What's its UUID?"             → Identity card (UUID inline)
+ *   3. "How do I (or my players) connect to it?"                     → Connection card
+ *   4. "What resources does it have?" + "What node am I on?"          → Resources card (Node inline)
+ *   5. "How does it start up, and what env vars drive it?"           → Startup section
+ *   6. "What if I need to wipe + reinstall?"                         → Danger zone
+ *
+ * Software wizard behaviour: the Change Software flow is a popout
+ * modal layered on top of this page (handled inside ShellContainer
+ * itself, see its render). The previous draft tried to swap between two
+ * separate ShellContainer subtrees ("inline overview" vs. "full-page
+ * wizard") which unmounted + re-mounted ShellContainer when the user
+ * clicked Change Software — and re-mounting reset its internal
+ * `currentStep` state, trapping the user on the overview.
+ *
+ * Legacy URLs (/startup, /shell) redirect to the corresponding section
+ * anchor here; see routes.ts + LegacyRedirects.tsx for the wiring.
+ */
 const SettingsContainer = () => {
-    const username = useStoreState((state) => state.user.data!.username);
-    const id = ServerContext.useStoreState((state) => state.server.data!.id);
-    const uuid = ServerContext.useStoreState((state) => state.server.data!.uuid);
-    const node = ServerContext.useStoreState((state) => state.server.data!.node);
-    const sftp = ServerContext.useStoreState((state) => state.server.data!.sftpDetails, isEqual);
+    const location = useLocation();
+
+    // On mount, if the user arrived via a deep-link anchor (e.g.
+    // /settings#startup from a legacy redirect or a toast action),
+    // scroll the matching section into view. Tiny setTimeout so refs
+    // are in the DOM before we call scrollIntoView.
+    useEffect(() => {
+        if (!location.hash) return;
+        const t = setTimeout(() => {
+            const id = location.hash.replace(/^#/, '');
+            document.getElementById(id)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }, 50);
+        return () => clearTimeout(t);
+    }, [location.hash]);
 
     return (
-        <ServerContentBlock title={'Settings'}>
-            <FlashMessageRender byKey={'settings'} />
-            <MainPageHeader direction='column' title={'Settings'}>
+        <ServerContentBlock title='Settings'>
+            <FlashMessageRender byKey='settings' />
+
+            <MainPageHeader direction='column' title='Settings'>
                 <p className='text-sm text-neutral-400 leading-relaxed'>
-                    Configure your server settings, manage SFTP access, and access debug information. Make changes to
-                    server name and reinstall when needed.
+                    Everything that controls how this server runs and what software it runs — in one place.
                 </p>
             </MainPageHeader>
-            <Can action={'settings.rename'}>
-                <div className={`mb-6 md:mb-10`}>
-                    <RenameServerBox />
-                </div>
-            </Can>
 
-            <div className='w-full h-full flex flex-col gap-8'>
-                <Can action={'settings.reinstall'}>
-                    <ReinstallServerBox />
+            <div className='flex flex-col gap-5'>
+                {/* Software hero card — top of page because "what am I
+                    running" is the single most-asked question on Settings.
+                    The Change Software flow opens as a modal layered over
+                    the rest of the Settings page. */}
+                <div id='software'>
+                    <ShellContainer embedded />
+                </div>
+
+                {/* Identity */}
+                <Can action='settings.rename'>
+                    <RenameServerBox />
                 </Can>
-                <TitledGreyBox title={'Debug Information'}>
-                    <div className={`flex items-center justify-between text-sm`}>
-                        <p>Node</p>
-                        <code className={`font-mono bg-zinc-900 rounded-sm py-1 px-2`}>{node}</code>
-                    </div>
-                    <CopyOnClick text={uuid}>
-                        <div className={`flex items-center justify-between mt-2 text-sm`}>
-                            <p>Server ID</p>
-                            <code className={`font-mono bg-zinc-900 rounded-sm py-1 px-2`}>{uuid}</code>
-                        </div>
-                    </CopyOnClick>
-                </TitledGreyBox>
-                <Can action={'file.sftp'}>
-                    <TitledGreyBox title={'SFTP Details'} className={`mb-6 md:mb-10`}>
-                        <div className={`flex items-center justify-between text-sm`}>
-                            <Label>Server Address</Label>
-                            <CopyOnClick text={`sftp://${ip(sftp.ip)}:${sftp.port}`}>
-                                <code
-                                    className={`font-mono bg-zinc-900 rounded-sm py-1 px-2`}
-                                >{`sftp://${ip(sftp.ip)}:${sftp.port}`}</code>
-                            </CopyOnClick>
-                        </div>
-                        <div className={`mt-2 flex items-center justify-between text-sm`}>
-                            <Label>Username</Label>
-                            <CopyOnClick text={`${username}.${id}`}>
-                                <code
-                                    className={`font-mono bg-zinc-900 rounded-sm py-1 px-2`}
-                                >{`${username}.${id}`}</code>
-                            </CopyOnClick>
-                        </div>
-                        <div className={`mt-6 flex items-center`}>
-                            <div className={`flex-1`}>
-                                <div className={`border-l-4 border-brand p-3`}>
-                                    <p className={`text-xs text-zinc-200`}>
-                                        Your SFTP password is the same as the password you use to access this panel.
-                                    </p>
-                                </div>
-                            </div>
-                            <div className={`ml-4`}>
-                                <a href={`sftp://${username}.${id}@${ip(sftp.ip)}:${sftp.port}`}>
-                                    <ActionButton variant='secondary'>Launch SFTP</ActionButton>
-                                </a>
-                            </div>
-                        </div>
-                    </TitledGreyBox>
+
+                {/* Connection — game address + SFTP + Launch button */}
+                <Can action='file.sftp'>
+                    <ServerConnectionCard />
+                </Can>
+
+                {/* Resources — memory / CPU / disk tiles */}
+                <ServerResourcesCard />
+
+                {/* Startup command + docker image + env vars */}
+                <div id='startup'>
+                    <StartupContainer embedded />
+                </div>
+
+                {/* Danger zone */}
+                <Can action='settings.reinstall'>
+                    <ReinstallServerBox />
                 </Can>
             </div>
         </ServerContentBlock>

--- a/resources/scripts/components/server/shell/ShellContainer.tsx
+++ b/resources/scripts/components/server/shell/ShellContainer.tsx
@@ -1,5 +1,6 @@
-import { Box, TriangleExclamation } from '@gravity-ui/icons';
-import { useEffect, useMemo, useState } from 'react';
+import { Box, TriangleExclamation, Xmark } from '@gravity-ui/icons';
+import { Dialog as HDialog } from '@headlessui/react';
+import { ReactNode, useEffect, useMemo, useState } from 'react';
 import isEqual from 'react-fast-compare';
 import { toast } from 'sonner';
 
@@ -249,7 +250,74 @@ const validateEnvironmentVariables = (variables: any[], pendingVariables: Record
     return errors;
 };
 
-const SoftwareContainer = () => {
+interface SoftwareContainerProps {
+    /**
+     * When true, render WITHOUT the outer ServerContentBlock / MainPageHeader
+     * chrome. The consolidated Settings page owns the page chrome and uses
+     * this prop so the Software section just renders its body inline.
+     */
+    embedded?: boolean;
+    /**
+     * Fires whenever the wizard's currentStep changes. The consolidated
+     * Settings page uses this to hide its other sections (General, Startup)
+     * once the wizard moves past the overview, so the wizard takes the full
+     * page just like the user expected.
+     */
+    onActiveStepChange?: (step: FlowStep) => void;
+}
+
+interface SoftwareWizardDialogProps {
+    visible: boolean;
+    onDismissed: () => void;
+    children: ReactNode;
+}
+
+const SoftwareWizardDialog = ({ visible, onDismissed, children }: SoftwareWizardDialogProps) => {
+    useEffect(() => {
+        if (!visible) return;
+
+        const onKeyDown = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') onDismissed();
+        };
+
+        document.addEventListener('keydown', onKeyDown);
+        return () => document.removeEventListener('keydown', onKeyDown);
+    }, [visible, onDismissed]);
+
+    if (!visible) return null;
+
+    return (
+        <HDialog static open={visible} onClose={() => {}} className='relative z-9998'>
+            <div aria-hidden='true' className='fixed inset-0 z-9997 bg-black/85 backdrop-blur-xs' />
+            <div className='fixed inset-0 z-9998 overflow-y-auto'>
+                <div className='flex min-h-full items-start justify-center px-4 py-8 sm:px-6'>
+                    <HDialog.Panel className='relative w-full max-w-[88rem] rounded-2xl border border-[#ffffff07] bg-[#151515]/95 text-left shadow-2xl backdrop-blur-3xl'>
+                        <button
+                            type='button'
+                            onClick={onDismissed}
+                            className='absolute left-6 top-6 z-10 inline-flex h-9 w-9 items-center justify-center rounded-lg text-zinc-500 transition hover:bg-[#ffffff10] hover:text-white'
+                            title='Close'
+                        >
+                            <Xmark width={18} height={18} fill='currentColor' />
+                        </button>
+                        <div className='max-h-[82vh] overflow-y-auto px-6 pb-6 pt-20'>{children}</div>
+                    </HDialog.Panel>
+                </div>
+            </div>
+        </HDialog>
+    );
+};
+
+// million-ignore
+// Million.js auto-mode rewrites this component's virtual DOM and that
+// causes the wizard <Modal> to unmount + remount on every state change
+// inside the wizard — even unrelated ones like flipping the "Create
+// Backup" toggle. Visible symptom: the headlessui-portal-root briefly
+// disappears and reappears, the modal animation re-plays, and any
+// open inner dropdowns slam shut. Opting this component out of
+// Million keeps React's normal reconciler (which preserves the modal
+// instance across re-renders) in charge.
+const SoftwareContainer = ({ embedded = false, onActiveStepChange }: SoftwareContainerProps = {}) => {
     const serverData = ServerContext.useStoreState((state) => state.server.data);
     const daemonType = getGlobalDaemonType();
     const uuid = serverData?.uuid;
@@ -280,6 +348,12 @@ const SoftwareContainer = () => {
 
     // Flow state
     const [currentStep, setCurrentStep] = useState<FlowStep>('overview');
+    // Notify the parent (consolidated Settings page) whenever the wizard
+    // moves between overview and active steps. Parent uses this to swap
+    // between sectioned layout (overview) and full-page wizard takeover.
+    useEffect(() => {
+        onActiveStepChange?.(currentStep);
+    }, [currentStep, onActiveStepChange]);
     const [isLoading, setIsLoading] = useState(false);
     const [selectedNest, setSelectedNest] = useState<Nest | null>(null);
     const [selectedEgg, setSelectedEgg] = useState<Egg | null>(null);
@@ -512,8 +586,8 @@ const SoftwareContainer = () => {
                 selectedDockerImage && eggPreview.docker_images
                     ? eggPreview.docker_images[selectedDockerImage]
                     : eggPreview.default_docker_image && eggPreview.docker_images
-                        ? eggPreview.docker_images[eggPreview.default_docker_image]
-                        : '';
+                      ? eggPreview.docker_images[eggPreview.default_docker_image]
+                      : '';
 
             // Filter out empty environment variables to prevent validation issues
             const filteredEnvironment: Record<string, string> = {};
@@ -724,35 +798,41 @@ const SoftwareContainer = () => {
             <div className='space-y-4'>
                 <p className='text-sm text-neutral-400'>Choose the specific software version for your server</p>
 
-                {isLoading ? (
-                    <div className='flex items-center justify-center py-16'>
-                        <div className='flex flex-col items-center text-center'>
-                            <Spinner size='large' />
-                            <p className='text-neutral-400 mt-4'>Loading software options...</p>
-                        </div>
-                    </div>
-                ) : (
-                    <div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 sm:gap-4'>
-                        {selectedNest?.attributes?.relationships?.eggs?.data?.map((egg) => (
+                {/* Keep the cards rendered while the egg-preview fetch
+                    is in flight — earlier versions swapped the entire
+                    grid out for a big centered Spinner, which produced
+                    a jarring "everything vanishes then a different
+                    page appears" jump between steps. Now the grid
+                    stays visible, the picked card shows an inline
+                    spinner + brand border so the user can see exactly
+                    which option is loading, and the other cards just
+                    grey out via the disabled state. */}
+                <div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 sm:gap-4'>
+                    {selectedNest?.attributes?.relationships?.eggs?.data?.map((egg) => {
+                        const isPicked = selectedEgg?.attributes?.uuid === egg?.attributes?.uuid;
+                        const isPickedAndLoading = isLoading && isPicked;
+                        return (
                             <button
                                 key={egg.attributes.uuid}
                                 onClick={() => handleEggSelection(egg)}
                                 disabled={isLoading}
-                                className='p-4 bg-[#ffffff08] border border-[#ffffff12] rounded-lg hover:border-[#ffffff20] transition-all text-left touch-manipulation disabled:opacity-50 disabled:cursor-not-allowed'
+                                className={`p-4 bg-[#ffffff08] border rounded-lg transition-all text-left touch-manipulation disabled:cursor-not-allowed ${
+                                    isPicked
+                                        ? 'border-brand/60 bg-brand/10'
+                                        : 'border-[#ffffff12] hover:border-[#ffffff20] disabled:opacity-40'
+                                }`}
                             >
                                 <div className='flex items-center gap-2 mb-2'>
-                                    {isLoading && selectedEgg?.attributes?.uuid === egg?.attributes?.uuid && (
-                                        <Spinner size='small' />
-                                    )}
+                                    {isPickedAndLoading && <Spinner size='small' />}
                                     <h3 className='font-semibold text-neutral-200 text-sm sm:text-base'>
                                         {egg?.attributes?.name}
                                     </h3>
                                 </div>
                                 {renderDescription(egg?.attributes?.description || '', `egg-${egg?.attributes?.uuid}`)}
                             </button>
-                        ))}
-                    </div>
-                )}
+                        );
+                    })}
+                </div>
 
                 <div className='flex flex-col sm:flex-row justify-center gap-3 pt-4'>
                     <ActionButton
@@ -829,7 +909,16 @@ const SoftwareContainer = () => {
                                                     </svg>
                                                 </button>
                                             </DropdownMenuTrigger>
-                                            <DropdownMenuContent className='w-full min-w-[300px]'>
+                                            {/* z-99999 lifts the menu above the Modal
+                                                (z-9998) — without this override the
+                                                dropdown opens behind the wizard's
+                                                backdrop, invisible and unclickable.
+                                                Same z-index StartupContainer uses for
+                                                its docker-image dropdown. */}
+                                            <DropdownMenuContent
+                                                className='w-full min-w-[300px] z-99999'
+                                                sideOffset={8}
+                                            >
                                                 <DropdownMenuRadioGroup
                                                     value={selectedDockerImage}
                                                     onValueChange={setSelectedDockerImage}
@@ -903,10 +992,11 @@ const SoftwareContainer = () => {
                                                             handleVariableChange(variable.env_variable, e.target.value)
                                                         }
                                                         placeholder={variable.default_value || 'Enter value...'}
-                                                        className={`w-full px-3 py-2 bg-[#ffffff08] border rounded-lg text-sm text-neutral-200 placeholder:text-neutral-500 focus:outline-none transition-colors ${variableErrors[variable.env_variable]
-                                                            ? 'border-red-500 focus:border-red-500'
-                                                            : 'border-[#ffffff12] focus:border-brand'
-                                                            }`}
+                                                        className={`w-full px-3 py-2 bg-[#ffffff08] border rounded-lg text-sm text-neutral-200 placeholder:text-neutral-500 focus:outline-none transition-colors ${
+                                                            variableErrors[variable.env_variable]
+                                                                ? 'border-red-500 focus:border-red-500'
+                                                                : 'border-[#ffffff12] focus:border-brand'
+                                                        }`}
                                                     />
                                                     {variableErrors[variable.env_variable] && (
                                                         <p className='text-xs text-red-400 mt-1'>
@@ -947,11 +1037,11 @@ const SoftwareContainer = () => {
                                         </label>
                                         <p className='text-xs text-neutral-400 leading-relaxed'>
                                             {backupLimit !== 0 &&
-                                                (backupLimit === null || (backups?.backupCount || 0) < backupLimit)
+                                            (backupLimit === null || (backups?.backupCount || 0) < backupLimit)
                                                 ? 'Automatically create a backup before applying changes'
                                                 : backupLimit === 0
-                                                    ? 'Backups are disabled for this server'
-                                                    : 'Backup limit reached'}
+                                                  ? 'Backups are disabled for this server'
+                                                  : 'Backup limit reached'}
                                         </p>
                                     </div>
                                     <div className='flex-shrink-0'>
@@ -1011,153 +1101,187 @@ const SoftwareContainer = () => {
             <TitledGreyBox title='Review Changes'>
                 {selectedEgg && eggPreview && (
                     <div className='space-y-6'>
-                        {/* Summary */}
+                        {/* Top-row summary spans the full width since the
+                            From → To diff reads better as a single
+                            horizontal band. 4-col grid on wide
+                            viewports fills the modal's ~1408px without
+                            looking sparse. */}
                         <div className='p-4 bg-[#ffffff08] border border-[#ffffff12] rounded-lg'>
                             <h3 className='text-lg font-semibold text-neutral-200 mb-4'>Change Summary</h3>
-                            <div className='grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm'>
+                            <div className='grid grid-cols-1 gap-4 text-sm sm:grid-cols-2 lg:grid-cols-4'>
                                 <div>
                                     <span className='text-neutral-400'>From:</span>
-                                    <div className='text-neutral-200 font-medium'>
+                                    <div className='text-neutral-200 font-medium break-words'>
                                         {currentEggName || 'No software'}
                                     </div>
                                 </div>
                                 <div>
                                     <span className='text-neutral-400'>To:</span>
-                                    <div className='text-brand font-medium'>{selectedEgg.attributes.name}</div>
+                                    <div className='text-brand font-medium break-words'>
+                                        {selectedEgg.attributes.name}
+                                    </div>
                                 </div>
                                 <div>
                                     <span className='text-neutral-400'>Category:</span>
-                                    <div className='text-neutral-200 font-medium'>{selectedNest?.attributes.name}</div>
+                                    <div className='text-neutral-200 font-medium break-words'>
+                                        {selectedNest?.attributes.name}
+                                    </div>
                                 </div>
                                 <div>
                                     <span className='text-neutral-400'>Docker Image:</span>
-                                    <div className='text-neutral-200 font-medium'>
+                                    <div className='text-neutral-200 font-medium break-words'>
                                         {selectedDockerImage || 'Default'}
                                     </div>
                                 </div>
                             </div>
                         </div>
 
-                        {/* Startup Command Review */}
-                        <div className='p-4 bg-[#ffffff08] border border-[#ffffff12] rounded-lg'>
-                            <h3 className='text-lg font-semibold text-neutral-200 mb-4'>Startup Configuration</h3>
-                            <div className='space-y-3'>
-                                <div>
-                                    <span className='text-neutral-400 text-sm'>Startup Command:</span>
-                                    <div className='mt-1 p-3 bg-[#ffffff08] border border-[#ffffff12] rounded-lg font-mono text-sm text-neutral-200 whitespace-pre-wrap'>
-                                        {customStartup || eggPreview.egg.startup}
-                                    </div>
-                                </div>
-                                <div>
-                                    <span className='text-neutral-400 text-sm'>Docker Image:</span>
-                                    <div className='mt-1 p-3 bg-[#ffffff08] border border-[#ffffff12] rounded-lg text-sm text-neutral-200'>
-                                        {selectedDockerImage || 'Default Image'}
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-
-                        {/* Configuration Review */}
-                        {eggPreview.variables.length > 0 && (
-                            <div className='p-4 bg-[#ffffff08] border border-[#ffffff12] rounded-lg'>
-                                <h3 className='text-lg font-semibold text-neutral-200 mb-4'>Variable Configuration</h3>
-                                <div className='space-y-2'>
-                                    {eggPreview.variables.map((variable) => (
-                                        <div
-                                            key={variable.env_variable}
-                                            className='flex justify-between items-center py-2 px-3 bg-[#ffffff08] rounded-lg'
-                                        >
-                                            <div>
-                                                <span className='text-neutral-200 font-medium'>{variable.name}</span>
-                                                <span className='text-neutral-500 text-sm ml-2 font-mono'>
-                                                    ({variable.env_variable})
-                                                </span>
-                                            </div>
-                                            <div className='text-brand font-mono text-sm'>
-                                                {pendingVariables[variable.env_variable] ||
-                                                    variable.default_value ||
-                                                    'Not set'}
+                        {/* Two-column layout fills the wide modal —
+                            left rail holds Startup config + Safety
+                            options (smaller, scan-once data), right
+                            rail holds the Variables list which is the
+                            tallest block and benefits from the bigger
+                            half. Stacks back to a single column on lg-
+                            and-below so narrow viewports stay readable. */}
+                        <div className='grid grid-cols-1 gap-6 lg:grid-cols-2'>
+                            <div className='space-y-6'>
+                                {/* Startup Command Review */}
+                                <div className='p-4 bg-[#ffffff08] border border-[#ffffff12] rounded-lg'>
+                                    <h3 className='text-lg font-semibold text-neutral-200 mb-4'>
+                                        Startup Configuration
+                                    </h3>
+                                    <div className='space-y-3'>
+                                        <div>
+                                            <span className='text-neutral-400 text-sm'>Startup Command:</span>
+                                            <div className='mt-1 p-3 bg-[#ffffff08] border border-[#ffffff12] rounded-lg font-mono text-sm text-neutral-200 whitespace-pre-wrap break-all'>
+                                                {customStartup || eggPreview.egg.startup}
                                             </div>
                                         </div>
-                                    ))}
+                                        <div>
+                                            <span className='text-neutral-400 text-sm'>Docker Image:</span>
+                                            <div className='mt-1 p-3 bg-[#ffffff08] border border-[#ffffff12] rounded-lg text-sm text-neutral-200 break-all'>
+                                                {selectedDockerImage || 'Default Image'}
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+
+                                {/* Safety Options Review */}
+                                <div className='p-4 bg-[#ffffff08] border border-[#ffffff12] rounded-lg'>
+                                    <h3 className='text-lg font-semibold text-neutral-200 mb-4'>Safety Options</h3>
+                                    <div className='space-y-2'>
+                                        <div className='flex justify-between items-center py-2 px-3 bg-[#ffffff08] rounded-lg'>
+                                            <span className='text-neutral-200'>Create Backup</span>
+                                            <span className={shouldBackup ? 'text-green-400' : 'text-neutral-400'}>
+                                                {shouldBackup ? 'Yes' : 'No'}
+                                            </span>
+                                        </div>
+                                        <div className='flex justify-between items-center py-2 px-3 bg-[#ffffff08] rounded-lg'>
+                                            <span className='text-neutral-200'>Wipe Files</span>
+                                            <span className={shouldWipe ? 'text-amber-400' : 'text-neutral-400'}>
+                                                {shouldWipe ? 'Yes' : 'No'}
+                                            </span>
+                                        </div>
+                                    </div>
                                 </div>
                             </div>
-                        )}
 
-                        {/* Safety Options Review */}
-                        <div className='p-4 bg-[#ffffff08] border border-[#ffffff12] rounded-lg'>
-                            <h3 className='text-lg font-semibold text-neutral-200 mb-4'>Safety Options</h3>
-                            <div className='space-y-2'>
-                                <div className='flex justify-between items-center py-2 px-3 bg-[#ffffff08] rounded-lg'>
-                                    <span className='text-neutral-200'>Create Backup</span>
-                                    <span className={shouldBackup ? 'text-green-400' : 'text-neutral-400'}>
-                                        {shouldBackup ? 'Yes' : 'No'}
-                                    </span>
-                                </div>
-                                <div className='flex justify-between items-center py-2 px-3 bg-[#ffffff08] rounded-lg'>
-                                    <span className='text-neutral-200'>Wipe Files</span>
-                                    <span className={shouldWipe ? 'text-amber-400' : 'text-neutral-400'}>
-                                        {shouldWipe ? 'Yes' : 'No'}
-                                    </span>
-                                </div>
-                            </div>
-                        </div>
-
-                        {/* Subdomain Warnings */}
-                        {eggPreview.warnings && eggPreview.warnings.length > 0 && (
-                            <div className='space-y-3'>
-                                {eggPreview.warnings.map((warning, index) => (
-                                    <div
-                                        key={index}
-                                        className={`p-4 border rounded-lg ${warning.severity === 'error'
-                                            ? 'bg-red-500/10 border-red-500/20'
-                                            : 'bg-amber-500/10 border-amber-500/20'
-                                            }`}
-                                    >
-                                        <div className='flex items-start gap-3'>
-                                            <TriangleExclamation
-                                                width={22}
-                                                height={22}
-                                                fill='currentColor'
-                                                className={`w-5 h-5 flex-shrink-0 mt-0.5 ${warning.severity === 'error' ? 'text-red-400' : 'text-amber-400'
-                                                    }`}
-                                            />
-                                            <div>
-                                                <h4
-                                                    className={`font-semibold mb-2 ${warning.severity === 'error' ? 'text-red-400' : 'text-amber-400'
-                                                        }`}
+                            {/* Right rail — variables (potentially long
+                                list, gets its own scroll cap), warnings,
+                                and the final general "this will…" notice. */}
+                            <div className='space-y-6'>
+                                {eggPreview.variables.length > 0 && (
+                                    <div className='p-4 bg-[#ffffff08] border border-[#ffffff12] rounded-lg'>
+                                        <h3 className='text-lg font-semibold text-neutral-200 mb-4'>
+                                            Variable Configuration
+                                        </h3>
+                                        <div className='space-y-2 max-h-72 overflow-y-auto pr-1'>
+                                            {eggPreview.variables.map((variable) => (
+                                                <div
+                                                    key={variable.env_variable}
+                                                    className='flex justify-between items-center gap-3 py-2 px-3 bg-[#ffffff08] rounded-lg'
                                                 >
-                                                    {warning.type === 'subdomain_incompatible'
-                                                        ? 'Subdomain Will Be Deleted'
-                                                        : 'Warning'}
-                                                </h4>
-                                                <p className='text-sm text-neutral-300'>{warning.message}</p>
-                                            </div>
+                                                    <div className='min-w-0'>
+                                                        <span className='text-neutral-200 font-medium block truncate'>
+                                                            {variable.name}
+                                                        </span>
+                                                        <span className='text-neutral-500 text-xs font-mono block truncate'>
+                                                            {variable.env_variable}
+                                                        </span>
+                                                    </div>
+                                                    <div className='text-brand font-mono text-sm truncate max-w-[40%] text-right'>
+                                                        {pendingVariables[variable.env_variable] ||
+                                                            variable.default_value ||
+                                                            'Not set'}
+                                                    </div>
+                                                </div>
+                                            ))}
                                         </div>
                                     </div>
-                                ))}
-                            </div>
-                        )}
+                                )}
 
-                        {/* General Warning */}
-                        <div className='p-4 bg-amber-500/10 border border-amber-500/20 rounded-lg'>
-                            <div className='flex items-start gap-3'>
-                                <TriangleExclamation
-                                    width={22}
-                                    height={22}
-                                    fill='currentColor'
-                                    className='w-5 h-5 text-amber-400 flex-shrink-0 mt-0.5'
-                                />
-                                <div>
-                                    <h4 className='text-amber-400 font-semibold mb-2'>This will:</h4>
-                                    <ul className='text-sm text-neutral-300'>
-                                        <li>• Stop and reinstall your server</li>
-                                        <li>• Take several minutes to complete</li>
-                                        <li>• Modify and remove some files</li>
-                                    </ul>
-                                    <span className='text-sm font-bold mt-4'>
-                                        Please ensure you have backups of important data before proceeding.
-                                    </span>
+                                {eggPreview.warnings && eggPreview.warnings.length > 0 && (
+                                    <div className='space-y-3'>
+                                        {eggPreview.warnings.map((warning, index) => (
+                                            <div
+                                                key={index}
+                                                className={`p-4 border rounded-lg ${
+                                                    warning.severity === 'error'
+                                                        ? 'bg-red-500/10 border-red-500/20'
+                                                        : 'bg-amber-500/10 border-amber-500/20'
+                                                }`}
+                                            >
+                                                <div className='flex items-start gap-3'>
+                                                    <TriangleExclamation
+                                                        width={22}
+                                                        height={22}
+                                                        fill='currentColor'
+                                                        className={`w-5 h-5 flex-shrink-0 mt-0.5 ${
+                                                            warning.severity === 'error'
+                                                                ? 'text-red-400'
+                                                                : 'text-amber-400'
+                                                        }`}
+                                                    />
+                                                    <div>
+                                                        <h4
+                                                            className={`font-semibold mb-2 ${
+                                                                warning.severity === 'error'
+                                                                    ? 'text-red-400'
+                                                                    : 'text-amber-400'
+                                                            }`}
+                                                        >
+                                                            {warning.type === 'subdomain_incompatible'
+                                                                ? 'Subdomain Will Be Deleted'
+                                                                : 'Warning'}
+                                                        </h4>
+                                                        <p className='text-sm text-neutral-300'>{warning.message}</p>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        ))}
+                                    </div>
+                                )}
+
+                                <div className='p-4 bg-amber-500/10 border border-amber-500/20 rounded-lg'>
+                                    <div className='flex items-start gap-3'>
+                                        <TriangleExclamation
+                                            width={22}
+                                            height={22}
+                                            fill='currentColor'
+                                            className='w-5 h-5 text-amber-400 flex-shrink-0 mt-0.5'
+                                        />
+                                        <div>
+                                            <h4 className='text-amber-400 font-semibold mb-2'>This will:</h4>
+                                            <ul className='text-sm text-neutral-300'>
+                                                <li>• Stop and reinstall your server</li>
+                                                <li>• Take several minutes to complete</li>
+                                                <li>• Modify and remove some files</li>
+                                            </ul>
+                                            <span className='text-sm font-bold mt-4'>
+                                                Please ensure you have backups of important data before proceeding.
+                                            </span>
+                                        </div>
+                                    </div>
                                 </div>
                             </div>
                         </div>
@@ -1186,17 +1310,25 @@ const SoftwareContainer = () => {
         </div>
     );
 
+    // When embedded the parent owns the outer ServerContentBlock — we
+    // render with a fragment instead so the page chrome isn't duplicated.
+    const ContentChrome = embedded
+        ? ({ children }: { children: React.ReactNode }) => <>{children}</>
+        : ({ children }: { children: React.ReactNode }) => (
+              <ServerContentBlock title='Software Management'>{children}</ServerContentBlock>
+          );
+
     // Show loading state if server data is not available
     if (!serverData) {
         return (
-            <ServerContentBlock title='Software Management'>
+            <ContentChrome>
                 <div className='flex items-center justify-center h-64'>
                     <div className='flex flex-col items-center text-center'>
                         <Spinner size='large' />
                         <p className='text-neutral-400 mt-4'>Loading server information...</p>
                     </div>
                 </div>
-            </ServerContentBlock>
+            </ContentChrome>
         );
     }
     function RenderOperationModal() {
@@ -1227,47 +1359,70 @@ const SoftwareContainer = () => {
         return <div>Could not find Operation Modal for this daemon: Using ${daemonType}</div>;
     }
     return (
-        <ServerContentBlock title='Software Management'>
+        <ContentChrome>
             <div className='space-y-6'>
-                <MainPageHeader direction='column' title='Software Management'>
-                    <p className='text-neutral-400 leading-relaxed'>
-                        Change your server&apos;s game or software with our guided configuration wizard
-                    </p>
-                </MainPageHeader>
-
-                {/* Progress indicator */}
-                {currentStep !== 'overview' && (
-                    <div className='p-4 bg-[#ffffff08] border border-[#ffffff12] rounded-lg'>
-                        <div className='flex items-center justify-between mb-2'>
-                            <span className='text-sm font-medium text-neutral-200 capitalize'>
-                                {currentStep.replace('-', ' ')}
-                            </span>
-                            <span className='text-sm text-neutral-400'>
-                                Step{' '}
-                                {['overview', 'select-game', 'select-software', 'configure', 'review'].indexOf(
-                                    currentStep,
-                                )}{' '}
-                                of 4
-                            </span>
-                        </div>
-                        <div className='w-full bg-[#ffffff12] rounded-full h-2'>
-                            <div
-                                className='bg-brand h-2 rounded-full transition-all duration-300'
-                                style={{
-                                    width: `${(['overview', 'select-game', 'select-software', 'configure', 'review'].indexOf(currentStep) / 4) * 100}%`,
-                                }}
-                            ></div>
-                        </div>
-                    </div>
+                {!embedded && (
+                    <MainPageHeader direction='column' title='Software Management'>
+                        <p className='text-neutral-400 leading-relaxed'>
+                            Change your server&apos;s game or software with our guided configuration wizard
+                        </p>
+                    </MainPageHeader>
                 )}
 
-                {/* Step Content */}
-                {currentStep === 'overview' && renderOverview()}
-                {currentStep === 'select-game' && renderGameSelection()}
-                {currentStep === 'select-software' && renderSoftwareSelection()}
-                {currentStep === 'configure' && renderConfiguration()}
-                {currentStep === 'review' && renderReview()}
+                {/* Overview is always rendered as the in-page card. The
+                    wizard steps (select-game → review) used to swap into
+                    this slot, which forced the embedded-inside-Settings
+                    layout to unmount ShellContainer + re-mount it in a
+                    separate "wizard takeover" subtree — and that lost
+                    the internal `currentStep` on the re-mount, trapping
+                    the user on the overview. Moving the wizard into a
+                    fixed-position modal (below) keeps ShellContainer
+                    mounted once + lets the wizard layer on top, the
+                    same shape as VersionSwitcherModal on the mods page. */}
+                {renderOverview()}
             </div>
+
+            {/* Dedicated wizard dialog. This intentionally does not use
+                the shared animated Modal wrapper: the wizard changes
+                substantial content on every step, and the shared wrapper's
+                motion lifecycle can make those normal state updates look
+                like the modal closed and reopened. This dialog stays
+                mounted as one stable panel while only its inner content
+                changes. */}
+            <SoftwareWizardDialog visible={currentStep !== 'overview'} onDismissed={() => setCurrentStep('overview')}>
+                <div className='space-y-6'>
+                    {/* Progress indicator */}
+                    {currentStep !== 'overview' && (
+                        <div className='p-4 bg-[#ffffff08] border border-[#ffffff12] rounded-lg'>
+                            <div className='flex items-center justify-between mb-2'>
+                                <span className='text-sm font-medium text-neutral-200 capitalize'>
+                                    {currentStep.replace('-', ' ')}
+                                </span>
+                                <span className='text-sm text-neutral-400'>
+                                    Step{' '}
+                                    {['overview', 'select-game', 'select-software', 'configure', 'review'].indexOf(
+                                        currentStep,
+                                    )}{' '}
+                                    of 4
+                                </span>
+                            </div>
+                            <div className='w-full bg-[#ffffff12] rounded-full h-2'>
+                                <div
+                                    className='bg-brand h-2 rounded-full transition-all duration-300'
+                                    style={{
+                                        width: `${(['overview', 'select-game', 'select-software', 'configure', 'review'].indexOf(currentStep) / 4) * 100}%`,
+                                    }}
+                                ></div>
+                            </div>
+                        </div>
+                    )}
+
+                    {currentStep === 'select-game' && renderGameSelection()}
+                    {currentStep === 'select-software' && renderSoftwareSelection()}
+                    {currentStep === 'configure' && renderConfiguration()}
+                    {currentStep === 'review' && renderReview()}
+                </div>
+            </SoftwareWizardDialog>
 
             {/* Wipe Files Confirmation Modal */}
             <ConfirmationModal
@@ -1315,7 +1470,7 @@ const SoftwareContainer = () => {
 
             {/* Operation Progress Modal */}
             {RenderOperationModal()}
-        </ServerContentBlock>
+        </ContentChrome>
     );
 };
 

--- a/resources/scripts/components/server/startup/StartupContainer.tsx
+++ b/resources/scripts/components/server/startup/StartupContainer.tsx
@@ -345,16 +345,25 @@ const StartupContainer = ({ embedded = false }: StartupContainerProps = {}) => {
                                 runtime. Egg-defined variables (listed in <em>Environment Variables</em> below) work the
                                 same way — wrap the name in <code className='font-mono text-zinc-400'>{'{{...}}'}</code>.
                             </p>
+                            {/*
+                                Values shown here are the literal substitution
+                                strings StartupCommandService::handle() will
+                                splice into the command at runtime — no units,
+                                formatting, or sentinels added on top. Hints
+                                explain what the raw number actually means
+                                (MiB / percent / etc.) without polluting the
+                                value cell.
+                            */}
                             <div className='grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3'>
                                 <BuiltinVariableChip
                                     placeholder='{{SERVER_MEMORY}}'
-                                    value={`${serverLimits.memory} MiB`}
+                                    value={String(serverLimits.memory)}
                                     hint='Memory limit allocated to the container, in MiB.'
                                 />
                                 <BuiltinVariableChip
                                     placeholder='{{SERVER_CPU}}'
-                                    value={serverLimits.cpu === 0 ? 'Unlimited' : `${serverLimits.cpu}%`}
-                                    hint='CPU limit as a percentage of a single core (0 = unlimited).'
+                                    value={String(serverLimits.cpu)}
+                                    hint='CPU limit as a percentage of a single core. 0 means unlimited.'
                                 />
                                 <BuiltinVariableChip
                                     placeholder='{{SERVER_IP}}'

--- a/resources/scripts/components/server/startup/StartupContainer.tsx
+++ b/resources/scripts/components/server/startup/StartupContainer.tsx
@@ -340,11 +340,6 @@ const StartupContainer = ({ embedded = false }: StartupContainerProps = {}) => {
                                 </h4>
                                 <span className='text-[11px] text-zinc-500'>Click to copy placeholder</span>
                             </div>
-                            <p className='mb-3 text-xs leading-relaxed text-neutral-500'>
-                                These placeholders are always available in the startup command and are substituted at
-                                runtime. Egg-defined variables (listed in <em>Environment Variables</em> below) work the
-                                same way — wrap the name in <code className='font-mono text-zinc-400'>{'{{...}}'}</code>.
-                            </p>
                             {/*
                                 Values shown here are the literal substitution
                                 strings StartupCommandService::handle() will

--- a/resources/scripts/components/server/startup/StartupContainer.tsx
+++ b/resources/scripts/components/server/startup/StartupContainer.tsx
@@ -1,3 +1,4 @@
+import { Copy } from '@gravity-ui/icons';
 import { useEffect, useState } from 'react';
 import isEqual from 'react-fast-compare';
 
@@ -28,6 +29,8 @@ import setSelectedDockerImage from '@/api/server/setSelectedDockerImage';
 import updateStartupCommand from '@/api/server/updateStartupCommand';
 import getServerStartup from '@/api/swr/getServerStartup';
 
+import { ip as ipFormatter } from '@/lib/formatters';
+
 import { ServerContext } from '@/state/server';
 
 import { useDeepCompareEffect } from '@/plugins/useDeepCompareEffect';
@@ -44,6 +47,48 @@ interface StartupContainerProps {
      */
     embedded?: boolean;
 }
+
+/**
+ * Single click-to-copy chip for one of the six built-in `{{SERVER_*}}`
+ * placeholders. Renders the placeholder syntax (so users learn the
+ * `{{VAR}}` form they'd type into the editor) alongside the current
+ * resolved value for this server, so it doubles as an at-a-glance
+ * reference.
+ *
+ * Defined as a top-level component (rather than inlined inside
+ * StartupContainer) so each chip's hover state is a clean
+ * Tailwind transition rather than re-rendering through the parent's
+ * state on every keystroke in the command editor above it.
+ */
+interface BuiltinVariableChipProps {
+    placeholder: string;
+    value: string;
+    hint: string;
+}
+const BuiltinVariableChip = ({ placeholder, value, hint }: BuiltinVariableChipProps) => (
+    <CopyOnClick text={placeholder}>
+        <div
+            // group + per-item border so the hover state is visibly
+            // scoped to the chip you're pointing at (otherwise it
+            // visually merges with the neighbour). Same spotlight idiom
+            // the rest of the Settings page uses.
+            className='group flex cursor-pointer items-center justify-between gap-3 rounded-lg border border-[#ffffff10] bg-[#ffffff06] px-3 py-2 transition hover:duration-0 hover:border-[#ffffff22] hover:bg-[#ffffff0c]'
+            title={hint}
+        >
+            <div className='flex min-w-0 flex-col leading-tight'>
+                <span className='truncate font-mono text-xs text-zinc-100'>{placeholder}</span>
+                <span className='truncate text-[11px] text-zinc-500' title={value}>
+                    {value}
+                </span>
+            </div>
+            <Copy
+                width={12}
+                height={12}
+                className='shrink-0 text-zinc-500 transition group-hover:text-zinc-200'
+            />
+        </div>
+    </CopyOnClick>
+);
 
 const StartupContainer = ({ embedded = false }: StartupContainerProps = {}) => {
     const [loading, setLoading] = useState(false);
@@ -65,6 +110,15 @@ const StartupContainer = ({ embedded = false }: StartupContainerProps = {}) => {
         }),
         isEqual,
     );
+    // Pulled separately (and shallow-compared) so the keystroke-level
+    // re-renders of the command editor don't drag the full server
+    // object through Easy-Peasy's selector pipeline on every keystroke.
+    // These feed the "Built-in variables" reference chips below the
+    // command editor.
+    const serverName = ServerContext.useStoreState((state) => state.server.data!.name);
+    const serverLimits = ServerContext.useStoreState((state) => state.server.data!.limits, isEqual);
+    const serverAllocations = ServerContext.useStoreState((state) => state.server.data!.allocations, isEqual);
+    const primaryAllocation = serverAllocations.find((a) => a.isDefault) ?? serverAllocations[0];
 
     const { data, error, isValidating, mutate } = getServerStartup(uuid, {
         ...variables,
@@ -264,6 +318,67 @@ const StartupContainer = ({ embedded = false }: StartupContainerProps = {}) => {
                                 processed version with variables resolved.
                             </p>
                         </div>
+
+                        {/*
+                            Built-in variables panel. Always visible inside
+                            the Startup Command card (in both view and edit
+                            modes) because the most useful time to know
+                            what placeholders exist is also the most likely
+                            time to need them — staring at the command
+                            field. The six SERVER_* names listed here are
+                            the ones StartupCommandService::handle()
+                            substitutes server-side (app/Services/Servers/
+                            StartupCommandService.php) before any egg
+                            variables; click any chip to copy the
+                            `{{...}}` form into your clipboard so you can
+                            paste it straight into the editor.
+                        */}
+                        <div className='mb-6 rounded-xl border border-[#ffffff10] bg-[#ffffff04] p-4'>
+                            <div className='mb-3 flex items-baseline justify-between gap-2'>
+                                <h4 className='text-[11px] font-bold uppercase tracking-wide text-zinc-400'>
+                                    Built-in variables
+                                </h4>
+                                <span className='text-[11px] text-zinc-500'>Click to copy placeholder</span>
+                            </div>
+                            <p className='mb-3 text-xs leading-relaxed text-neutral-500'>
+                                These placeholders are always available in the startup command and are substituted at
+                                runtime. Egg-defined variables (listed in <em>Environment Variables</em> below) work the
+                                same way — wrap the name in <code className='font-mono text-zinc-400'>{'{{...}}'}</code>.
+                            </p>
+                            <div className='grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3'>
+                                <BuiltinVariableChip
+                                    placeholder='{{SERVER_MEMORY}}'
+                                    value={`${serverLimits.memory} MiB`}
+                                    hint='Memory limit allocated to the container, in MiB.'
+                                />
+                                <BuiltinVariableChip
+                                    placeholder='{{SERVER_CPU}}'
+                                    value={serverLimits.cpu === 0 ? 'Unlimited' : `${serverLimits.cpu}%`}
+                                    hint='CPU limit as a percentage of a single core (0 = unlimited).'
+                                />
+                                <BuiltinVariableChip
+                                    placeholder='{{SERVER_IP}}'
+                                    value={primaryAllocation ? ipFormatter(primaryAllocation.ip) : '—'}
+                                    hint='IP of the primary allocation bound to this server.'
+                                />
+                                <BuiltinVariableChip
+                                    placeholder='{{SERVER_PORT}}'
+                                    value={primaryAllocation ? String(primaryAllocation.port) : '—'}
+                                    hint='Port of the primary allocation.'
+                                />
+                                <BuiltinVariableChip
+                                    placeholder='{{SERVER_UUID}}'
+                                    value={uuid}
+                                    hint='Unique identifier for this server. Stable across restarts and renames.'
+                                />
+                                <BuiltinVariableChip
+                                    placeholder='{{SERVER_NAME}}'
+                                    value={serverName || '—'}
+                                    hint='Current display name of the server.'
+                                />
+                            </div>
+                        </div>
+
                         {editingCommand ? (
                             <div className='space-y-4'>
                                 <div className='grid grid-cols-1 xl:grid-cols-2 gap-4 md:gap-6'>

--- a/resources/scripts/components/server/startup/StartupContainer.tsx
+++ b/resources/scripts/components/server/startup/StartupContainer.tsx
@@ -34,7 +34,18 @@ import { useDeepCompareEffect } from '@/plugins/useDeepCompareEffect';
 import useFlash from '@/plugins/useFlash';
 import { usePermissions } from '@/plugins/usePermissions';
 
-const StartupContainer = () => {
+interface StartupContainerProps {
+    /**
+     * When true, render WITHOUT the outer ServerContentBlock / MainPageHeader
+     * chrome — used by the consolidated Settings page (which renders its own
+     * outer chrome and stacks this container as one of several sections).
+     * Defaults to false so any direct mount (legacy redirects, deep-link
+     * fallbacks) still gets a complete page.
+     */
+    embedded?: boolean;
+}
+
+const StartupContainer = ({ embedded = false }: StartupContainerProps = {}) => {
     const [loading, setLoading] = useState(false);
     const [commandLoading, setCommandLoading] = useState(false);
     const [editingCommand, setEditingCommand] = useState(false);
@@ -46,7 +57,6 @@ const StartupContainer = () => {
     const [canEditDockerImage] = usePermissions(['startup.docker-image']);
 
     const uuid = ServerContext.useStoreState((state) => state.server.data!.uuid);
-    const server = ServerContext.useStoreState((state) => state.server.data!, isEqual);
     const variables = ServerContext.useStoreState(
         ({ server }) => ({
             variables: server.data!.variables,
@@ -62,7 +72,10 @@ const StartupContainer = () => {
         rawStartupCommand: '',
     });
 
-    const ITEMS_PER_PAGE = 6;
+    // 8 per page rather than 6 so the 4-column xl grid below always
+    // breaks cleanly into two full rows on a page (8 = 2 × 4) instead
+    // of leaving a half-empty row at the bottom.
+    const ITEMS_PER_PAGE = 8;
     const [currentPage, setCurrentPage] = useState(1);
 
     const paginatedVariables = data
@@ -184,6 +197,17 @@ const StartupContainer = () => {
         setLiveProcessedCommand(processed);
     };
 
+    // When embedded, ContentChrome is a passthrough fragment — the parent
+    // SettingsContainer is already providing the outer ServerContentBlock
+    // and a page-level header, so we don't want to render duplicates.
+    const ContentChrome = embedded
+        ? ({ children }: { children: React.ReactNode }) => <>{children}</>
+        : ({ children }: { children: React.ReactNode }) => (
+              <ServerContentBlock title={'Startup Settings'} showFlashKey={'startup:image'}>
+                  {children}
+              </ServerContentBlock>
+          );
+
     return !data ? (
         !error || (error && isValidating) ? (
             <div className='flex items-center justify-center min-h-[60vh]'>
@@ -196,7 +220,7 @@ const StartupContainer = () => {
             <ServerError title={'Oops!'} message={httpErrorToHuman(error)} />
         )
     ) : (
-        <ServerContentBlock title={'Startup Settings'} showFlashKey={'startup:image'}>
+        <ContentChrome>
             <Dialog.Confirm
                 open={revertModalVisible}
                 title={'Revert Docker Image'}
@@ -219,16 +243,18 @@ const StartupContainer = () => {
                 </div>
             </Dialog.Confirm>
             <div className='space-y-6'>
-                <MainPageHeader direction='column' title='Startup Settings'>
-                    <p className='text-sm text-neutral-400 leading-relaxed'>
-                        Configure how your server starts up. These settings control the startup command and environment
-                        variables.
-                        <span className='text-amber-400 font-medium'>
-                            {' '}
-                            Exercise caution when modifying these settings.
-                        </span>
-                    </p>
-                </MainPageHeader>
+                {!embedded && (
+                    <MainPageHeader direction='column' title='Startup Settings'>
+                        <p className='text-sm text-neutral-400 leading-relaxed'>
+                            Configure how your server starts up. These settings control the startup command and
+                            environment variables.
+                            <span className='text-amber-400 font-medium'>
+                                {' '}
+                                Exercise caution when modifying these settings.
+                            </span>
+                        </p>
+                    </MainPageHeader>
+                )}
 
                 <div className='space-y-6'>
                     <TitledGreyBox title={'Startup Command'} className='p-6'>
@@ -496,92 +522,61 @@ const StartupContainer = () => {
                             </p>
                         </div>
 
-                        <div className='bg-linear-to-b from-[#ffffff04] to-[#ffffff02] border border-[#ffffff08] rounded-xl p-4'>
-                            <div className='space-y-3'>
-                                <h4 className='text-sm font-medium text-neutral-300'>Global Server Variables</h4>
-                                <div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 text-xs'>
-                                    <div className='flex justify-between items-center gap-2 py-2 px-3 bg-[#ffffff06] rounded border border-[#ffffff08]'>
-                                        <span className='font-mono text-neutral-400'>{'SERVER_MEMORY'}</span>
-                                        <CopyOnClick text={server?.limits?.memory || 'null'}>
-                                            <span className='text-neutral-300 font-mono'>
-                                                {server?.limits?.memory || 'null'}
-                                            </span>
-                                        </CopyOnClick>
-                                    </div>
-                                    <div className='flex justify-between items-center gap-2 py-2 px-3 bg-[#ffffff06] rounded border border-[#ffffff08]'>
-                                        <span className='font-mono text-neutral-400'>{'SERVER_IP'}</span>
-                                        <CopyOnClick text={server?.allocations?.find((a) => a.isDefault)?.ip || 'null'}>
-                                            <span className='text-neutral-300 font-mono'>
-                                                {server?.allocations?.find((a) => a.isDefault)?.ip || 'null'}
-                                            </span>
-                                        </CopyOnClick>
-                                    </div>
-                                    <div className='flex justify-between items-center gap-2 py-2 px-3 bg-[#ffffff06] rounded border border-[#ffffff08]'>
-                                        <span className='font-mono text-neutral-400'>{'SERVER_PORT'}</span>
-                                        <CopyOnClick
-                                            text={server?.allocations?.find((a) => a.isDefault)?.port || 'null'}
-                                        >
-                                            <span className='text-neutral-300 font-mono'>
-                                                {server?.allocations?.find((a) => a.isDefault)?.port || 'null'}
-                                            </span>
-                                        </CopyOnClick>
-                                    </div>
-                                    <div className='flex justify-between items-center gap-2 py-2 px-3 bg-[#ffffff06] rounded border border-[#ffffff08]'>
-                                        <span className='font-mono text-neutral-400'>{'SERVER_UUID'}</span>
-                                        <CopyOnClick text={uuid}>
-                                            <span className='text-neutral-300 font-mono text-xs truncate'>{uuid}</span>
-                                        </CopyOnClick>
-                                    </div>
-                                    <div className='flex justify-between items-center gap-2 py-2 px-3 bg-[#ffffff06] rounded border border-[#ffffff08]'>
-                                        <span className='font-mono text-neutral-400'>{'SERVER_NAME'}</span>
-                                        <CopyOnClick text={server?.name || 'null'}>
-                                            <span className='text-neutral-300 font-mono truncate'>
-                                                {server?.name || 'null'}
-                                            </span>
-                                        </CopyOnClick>
-                                    </div>
-                                    <div className='flex justify-between items-center gap-2 py-2 px-3 bg-[#ffffff06] rounded border border-[#ffffff08]'>
-                                        <span className='font-mono text-neutral-400'>{'SERVER_CPU'}</span>
-                                        <CopyOnClick text={server?.limits?.cpu || 'null'}>
-                                            <span className='text-neutral-300 font-mono'>
-                                                {server?.limits?.cpu || 'null'}
-                                            </span>
-                                        </CopyOnClick>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+                        {/*
+                            The old "Global Server Variables" tile grid
+                            (SERVER_MEMORY, SERVER_IP, SERVER_PORT,
+                            SERVER_UUID, SERVER_NAME, SERVER_CPU) used to
+                            live here. Every entry is now surfaced
+                            elsewhere on the Settings page in a more
+                            meaningful presentation:
+                              - SERVER_IP / SERVER_PORT → Connection card
+                              - SERVER_MEMORY / SERVER_CPU → Resources card
+                              - SERVER_UUID → Diagnostics footer
+                              - SERVER_NAME → Server Identity card
+                            Repeating them as a flat key/value grid here
+                            was duplicate noise.
+                        */}
 
-                        <div className='min-h-[40svh] flex flex-col justify-between'>
-                            <div className='grid gap-3 sm:gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3'>
-                                {paginatedVariables.map((variable) => (
-                                    <VariableBox key={variable.envVariable} variable={variable} />
-                                ))}
-                            </div>
-                            {data.variables.length > ITEMS_PER_PAGE && (
-                                <div className='mt-6 pt-4 border-t border-[#ffffff10]'>
-                                    <Pagination
-                                        data={{
-                                            items: paginatedVariables,
-                                            pagination: {
-                                                currentPage,
-                                                totalPages: Math.ceil(data.variables.length / ITEMS_PER_PAGE),
-                                                total: data.variables.length,
-                                                count: data.variables.length,
-                                                perPage: ITEMS_PER_PAGE,
-                                            },
-                                        }}
-                                        onPageSelect={setCurrentPage}
-                                    >
-                                        {() => <></>}
-                                    </Pagination>
-                                </div>
-                            )}
+                        {/* No `min-h-[40svh]` here on purpose — that
+                            reserved viewport height to pin the
+                            pagination to the bottom even when only one
+                            page of variables existed, but it left a big
+                            awkward gap below the variables on most
+                            servers (which have ≤ 8 variables and so
+                            never paginate). Content now flows naturally. */}
+                        {/* Skip the lg:grid-cols-3 step on the way down
+                            from xl:grid-cols-4: a 3-col grid with 4 vars
+                            lays out as 3+1, which looks unbalanced with
+                            the lone tile on row 2. Going 4 → 2 → 1
+                            keeps every breakpoint cleanly divisible. */}
+                        <div className='grid gap-3 sm:gap-4 grid-cols-1 sm:grid-cols-2 xl:grid-cols-4'>
+                            {paginatedVariables.map((variable) => (
+                                <VariableBox key={variable.envVariable} variable={variable} />
+                            ))}
                         </div>
+                        {data.variables.length > ITEMS_PER_PAGE && (
+                            <div className='mt-6 pt-4 border-t border-[#ffffff10]'>
+                                <Pagination
+                                    data={{
+                                        items: paginatedVariables,
+                                        pagination: {
+                                            currentPage,
+                                            totalPages: Math.ceil(data.variables.length / ITEMS_PER_PAGE),
+                                            total: data.variables.length,
+                                            count: data.variables.length,
+                                            perPage: ITEMS_PER_PAGE,
+                                        },
+                                    }}
+                                    onPageSelect={setCurrentPage}
+                                >
+                                    {() => <></>}
+                                </Pagination>
+                            </div>
+                        )}
                     </div>
                 )}
             </div>
-        </ServerContentBlock>
+        </ContentChrome>
     );
 };
 

--- a/resources/scripts/components/server/startup/VariableBox.tsx
+++ b/resources/scripts/components/server/startup/VariableBox.tsx
@@ -2,6 +2,8 @@ import { ChevronDown, ChevronUp, Lock } from '@gravity-ui/icons';
 import debounce from 'debounce';
 import { memo, useState } from 'react';
 import isEqual from 'react-fast-compare';
+import { useNavigate } from 'react-router-dom';
+import { toast } from 'sonner';
 
 import FlashMessageRender from '@/components/FlashMessageRender';
 import {
@@ -17,6 +19,35 @@ import { Input } from '@/components/elements/TextInput';
 
 import { ServerEggVariable } from '@/api/server/types';
 import updateStartupVariable from '@/api/server/updateStartupVariable';
+
+/**
+ * Env-variable names that drive the installer (and therefore won't take
+ * effect just by being saved as an env var — the user has to reinstall
+ * for the change to land on disk). When the user saves one of these from
+ * the Startup section we fire a friendly toast nudging them to the
+ * Software section, which is the path that actually triggers a reinstall.
+ *
+ * Kept as a set for O(1) lookup. The names are union'd across egg
+ * families: Modrinth uses MINECRAFT_VERSION, some older eggs use
+ * VANILLA_VERSION / MC_VERSION / GAME_VERSION, Paper/Velocity/Bungee
+ * advertise their own *_VERSION variants.
+ */
+const INSTALLER_DRIVEN_VARS = new Set<string>([
+    'MINECRAFT_VERSION',
+    'MC_VERSION',
+    'VANILLA_VERSION',
+    'GAME_VERSION',
+    'PAPER_VERSION',
+    'PURPUR_VERSION',
+    'FORGE_VERSION',
+    'FABRIC_VERSION',
+    'NEOFORGE_VERSION',
+    'QUILT_VERSION',
+    'BUILD_NUMBER',
+    'BUILD_TYPE',
+    'DL_PATH',
+    'SERVER_JARFILE',
+]);
 import getServerStartup from '@/api/swr/getServerStartup';
 
 import { ServerContext } from '@/state/server';
@@ -32,18 +63,29 @@ const VariableBox = ({ variable }: Props) => {
     const FLASH_KEY = `server:startup:${variable.envVariable}`;
 
     const uuid = ServerContext.useStoreState((state) => state.server.data!.uuid);
+    const serverId = ServerContext.useStoreState((state) => state.server.data!.id);
     const [loading, setLoading] = useState(false);
     const [canEdit] = usePermissions(['startup.update']);
     const { clearFlashes, clearAndAddHttpError } = useFlash();
     const { mutate } = getServerStartup(uuid);
     const [dropDownOpen, setDropDownOpen] = useState(false);
+    const navigate = useNavigate();
+
+    /**
+     * Track the value we last successfully saved so we only toast when the
+     * variable actually changed value. Without this, an idle blur (e.g.
+     * the user opens the dropdown, picks the same value, and the debounce
+     * fires anyway) would surface the reinstall reminder every time.
+     */
+    const [lastSavedValue, setLastSavedValue] = useState<string>(variable.serverValue ?? '');
 
     const setVariableValue = debounce((value: string) => {
         setLoading(true);
         clearFlashes(FLASH_KEY);
 
+        const previous = lastSavedValue;
         updateStartupVariable(uuid, variable.envVariable, value)
-            .then(([response, invocation]) =>
+            .then(([response, invocation]) => {
                 mutate(
                     (data) => ({
                         ...data!,
@@ -53,8 +95,26 @@ const VariableBox = ({ variable }: Props) => {
                         ),
                     }),
                     false,
-                ),
-            )
+                );
+                setLastSavedValue(value);
+                // Installer-driven variables (MINECRAFT_VERSION etc.) only
+                // really take effect after a reinstall — saving them as an
+                // env var doesn't swap out the jar on disk. Nudge the user
+                // toward the Software section, which IS the path that
+                // reinstalls. We deliberately gate on "value actually
+                // changed" so a no-op save doesn't toast.
+                if (INSTALLER_DRIVEN_VARS.has(variable.envVariable) && previous !== value) {
+                    toast.warning(`${variable.envVariable} changed`, {
+                        description:
+                            'The server will still launch with the existing files until you reinstall. Use the Software section to apply the change.',
+                        duration: 12000,
+                        action: {
+                            label: 'Go to Software',
+                            onClick: () => navigate(`/server/${serverId}/settings#software`),
+                        },
+                    });
+                }
+            })
             .catch((error) => {
                 console.error(error);
                 clearAndAddHttpError({ key: FLASH_KEY, error });

--- a/resources/scripts/routers/LegacyRedirects.tsx
+++ b/resources/scripts/routers/LegacyRedirects.tsx
@@ -1,0 +1,20 @@
+import { Navigate, useParams } from 'react-router-dom';
+
+/**
+ * Legacy URL redirectors used by `routes.ts`. The Startup and Software
+ * pages were consolidated into a single Settings page; these components
+ * keep external bookmarks and in-app links working by sending them to
+ * the matching section anchor on /settings.
+ *
+ * Kept in a `.tsx` file (rather than inline in routes.ts) so the routes
+ * config can remain a pure data module without picking up a JSX runtime.
+ */
+export const StartupRedirect = () => {
+    const { id } = useParams<{ id: string }>();
+    return <Navigate to={`/server/${id}/settings#startup`} replace />;
+};
+
+export const SoftwareRedirect = () => {
+    const { id } = useParams<{ id: string }>();
+    return <Navigate to={`/server/${id}/settings#software`} replace />;
+};

--- a/resources/scripts/routers/routes.ts
+++ b/resources/scripts/routers/routes.ts
@@ -1,5 +1,4 @@
 import {
-    Box,
     BranchesDown,
     ClockArrowRotateLeft,
     CloudArrowUpIn,
@@ -9,10 +8,11 @@ import {
     House,
     PencilToLine,
     Persons,
-    Terminal,
 } from '@gravity-ui/icons';
 import type { ComponentType, SVGProps } from 'react';
 import { lazy } from 'react';
+
+import { SoftwareRedirect, StartupRedirect } from '@/routers/LegacyRedirects';
 
 import AccountApiContainer from '@/components/dashboard/AccountApiContainer';
 import AccountOverviewContainer from '@/components/dashboard/AccountOverviewContainer';
@@ -27,11 +27,10 @@ import ModrinthContainer from '@/components/server/modrinth/ModrinthContainer';
 import NetworkContainer from '@/components/server/network/NetworkContainer';
 import ScheduleContainer from '@/components/server/schedules/ScheduleContainer';
 import SettingsContainer from '@/components/server/settings/SettingsContainer';
-import ShellContainer from '@/components/server/shell/ShellContainer';
-import StartupContainer from '@/components/server/startup/StartupContainer';
 import CreateUserContainer from '@/components/server/users/CreateUserContainer';
 import EditUserContainer from '@/components/server/users/EditUserContainer';
 import UsersContainer from '@/components/server/users/UsersContainer';
+
 
 // Each of the router files is already code split out appropriately — so
 // all the items above will only be loaded in when that router is loaded.
@@ -202,15 +201,6 @@ const routes: Routes = {
             isSubRoute: true,
         },
         {
-            route: 'startup/*',
-            path: 'startup',
-            permission: ['startup.read', 'startup.update', 'startup.docker-image'],
-            name: 'Startup',
-            component: StartupContainer,
-            icon: Terminal,
-            end: true,
-        },
-        {
             route: 'schedules/*',
             path: 'schedules',
             permission: 'schedule.*',
@@ -227,13 +217,52 @@ const routes: Routes = {
             isSubRoute: true,
         },
         {
+            // Consolidated Settings entry. The page renders General +
+            // Startup + Software as stacked sections — the previous
+            // dedicated Startup and Software sidebar items have been
+            // folded in here. Permission is the union of what each
+            // section needs so users with any one of them can still
+            // reach the page; per-section content is gated by `<Can>`
+            // checks inside the page itself.
             route: 'settings/*',
             path: 'settings',
-            permission: ['settings.*', 'file.sftp'],
+            permission: [
+                'settings.*',
+                'file.sftp',
+                'startup.read',
+                'startup.update',
+                'startup.docker-image',
+                'startup.software',
+            ],
             name: 'Settings',
             component: SettingsContainer,
             icon: Gear,
             end: true,
+            // Legacy /startup and /shell URLs both deep-link to a
+            // section on the Settings page (see the redirect routes
+            // below), so anchor-style paths under /settings should also
+            // highlight this entry.
+            highlightPatterns: [/^\/server\/[^/]+\/settings(\/.*)?$/],
+        },
+        {
+            // Legacy /startup → /settings#startup. Hidden from the
+            // sidebar; the SettingsContainer mounts at /settings and
+            // scrolls to the matching section anchor on hash arrival.
+            // The Navigate component handles the actual redirect.
+            route: 'startup/*',
+            permission: ['startup.read', 'startup.update', 'startup.docker-image'],
+            name: undefined,
+            component: StartupRedirect,
+            isSubRoute: true,
+        },
+        {
+            // Legacy /shell → /settings#software. Same shape as the
+            // /startup redirect above.
+            route: 'shell/*',
+            permission: 'startup.software',
+            name: undefined,
+            component: SoftwareRedirect,
+            isSubRoute: true,
         },
         {
             route: 'activity/*',
@@ -242,15 +271,6 @@ const routes: Routes = {
             name: 'Activity',
             component: ServerActivityLogContainer,
             icon: PencilToLine,
-            end: true,
-        },
-        {
-            route: 'shell/*',
-            path: 'shell',
-            permission: 'startup.software',
-            name: 'Software',
-            component: ShellContainer,
-            icon: Box,
             end: true,
         },
         {


### PR DESCRIPTION
## Summary

Consolidates the separate Startup and Software pages into the existing server Settings page.

Settings now contains:

- Software
- Identity
- Connection
- Resources
- Startup
- Danger zone

Startup and Software still use their existing containers, but both now support embedded rendering so Settings owns the page layout.

## Notes

- `/server/:id/startup/*` redirects to `/server/:id/settings#startup`.
- `/server/:id/shell/*` redirects to `/server/:id/settings#software`.
- The Settings route now covers the permissions needed by the embedded sections, while each section still gates its own controls.
- Change Software opens as a modal instead of replacing the Software section.
- Editing `MINECRAFT_VERSION`, `MC_VERSION`, `VANILLA_VERSION`, or `GAME_VERSION` shows a one-time compatibility warning.
- Startup now includes a built-in `{{SERVER_*}}` variable reference next to the startup command editor.

## UI changes

- Adds `ServerConnectionCard` for game address, SFTP address, SFTP username, and Launch SFTP.
- Adds `ServerResourcesCard` for memory, CPU, disk, node, and FQDN.
- Updates server identity and reinstall cards to match the new Settings layout.
- Updates the modal component so larger flows can provide a custom panel width and avoid background-click issues.

## Test plan

Build and read-only panel checks were completed on 2026-05-21. Configuration-changing checks are intentionally left unchecked.

- [x] Open Settings and verify all sections render in order.
- [x] Visit `/server/<id>/startup` and confirm it redirects to Settings and scrolls to Startup.
- [x] Visit `/server/<id>/shell` and confirm it redirects to Settings and scrolls to Software.
- [x] Open Change Software and move through the wizard without the modal closing or flickering.
- [x] Confirm dropdowns inside the Change Software modal render above the modal.
- [x] Edit a Minecraft version variable and confirm the warning toast appears once.
- [x] Copy each built-in `{{SERVER_*}}` variable chip.
- [x] Confirm the Connection card opens the expected `sftp://` URL. Verified the generated URL without launching an external SFTP client.
- [x] Confirm zero resource limits render as unlimited.
- [x] Check a limited subuser only sees the sections and actions their permissions allow.
- [x] `pnpm run build` passes for this PR worktree.
- [x] Settings, Startup redirect, Shell redirect, and Change Software modal checks ran without browser console warnings or errors.

## Relationship to other PRs

This is independent of #68. Both PRs touch `resources/scripts/routers/routes.ts`, so whichever merges second may need a small route/import conflict resolution.
